### PR TITLE
Update lib/pq dependency to avoid errors with Postgres 14

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
     ".",
     "oid"
   ]
-  revision = "88edab0803230a3898347e77b474f8c1820a1f20"
+  revision = "8c6de565f76fb5cd40a5c1b8ce583fbc3ba1bd0e"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,7 +14,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/lib/pq"
-  revision = "88edab0803230a3898347e77b474f8c1820a1f20"
+  revision = "8c6de565f76fb5cd40a5c1b8ce583fbc3ba1bd0e"
 
 [[constraint]]
   name = "github.com/segmentio/kafka-go"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository will only contain versions 1.2 and above due to that.
 
 or
 
-    curl -s -f -L -o await https://github.com/fcristovao/await/releases/download/v1.2.0/await-linux-amd64
+    curl -s -f -L -o await https://github.com/fcristovao/await/releases/download/v1.2.1/await-linux-amd64
     chmod +x await
 
 

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 	"time"
 )
 
-const version = "1.2.0"
+const version = "1.2.1"
 
 func main() {
 	var (


### PR DESCRIPTION
The following error is observed when trying to use await with Postgres 14:
  Resource unavailable: pq: unknown authentication response: 10

This is due to Postgres changing it's default to scram-sha-256 rather than md5.
Updating to the latest version of lib/pq resolves this issue