### PR TITLE
Build arm binary on both Ubuntu and MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        platform-arch: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform-arch }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,23 +6,14 @@ on:
     - '*'
 
 jobs:
-  release:
-
+  create_release:
     runs-on: ubuntu-latest
-
+    outputs:
+      upload_url: ${{ steps.create.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
-      - name: Make release
-        run: make rel
-
       - name: Create Release
-        id: create_release
+        id: create
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,24 +23,39 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Darwin binary
-        id: upload-darwin-release-asset
+  upload_binaries:
+    needs: create_release
+    strategy:
+      matrix:
+        platform-arch: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform-arch }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Make release
+        run: PLATFORM=${{ matrix.platform-arch }} make rel
+
+      - name: Upload amd64 binary
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./await-darwin-amd64
-          asset_name: await-darwin-amd64
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ./await-${{ matrix.platform-arch }}-amd64
+          asset_name: await-${{ matrix.platform-arch }}-amd64
           asset_content_type: application/octet-stream
 
-      - name: Upload Linux binary
-        id: upload-linux-release-asset
+      - name: Upload arm64 binary
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./await-linux-amd64
-          asset_name: await-linux-amd64
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ./await-${{ matrix.platform-arch }}-arm64
+          asset_name: await-${{ matrix.platform-arch }}-arm64
           asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,5 @@ test:
 
 .PHONY: rel
 rel:
-	GOOS=darwin GOARCH=amd64 go build -v -o await-darwin-amd64 .
-	GOOS=linux  GOARCH=amd64 go build -v -o await-linux-amd64  .
+	GOARCH=amd64 go build -v -o await-${PLATFORM}-amd64 .
+	GOARCH=arm64 go build -v -o await-${PLATFORM}-arm64 .


### PR DESCRIPTION
Hi @fcristovao 👋 

We are in need of natively built MacOS binaries of `await` so here's a PR that hopefully you can take a look at 😄 

The release workflow has been tested and the output can be seen here: [build-on-macos](https://github.com/onno-vos-dev/await/releases/tag/build-on-macos-2)